### PR TITLE
Add support for dropping root privileges and exiting immediately if there's an unhandled exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ usage: eap_proxy [-h] [--ping-gateway] [--ping-ip PING_IP]
                  [--ignore-when-wan-up] [--ignore-start] [--ignore-logoff]
                  [--restart-dhcp] [--set-mac] [--vlan-id VLAN_ID] [--daemon]
                  [--pidfile PIDFILE] [--syslog] [--promiscuous] [--debug]
-                 [--debug-packets]
+                 [--debug-packets] [--exit-on-failure] [--drop-root]
                  IF_WAN IF_ROUTER
 
 positional arguments:
@@ -139,4 +139,11 @@ debugging:
   --debug               enable debug-level logging
   --debug-packets       print packets in hex format to assist with debugging;
                         implies --debug
+
+security:
+  --exit-on-failure     exit immediately in case of an unhandled exception;
+                        assumes an external process will restart the script if
+                        needed
+  --drop-root           drop root privileges after opening sockets; implies
+                        --exit-on-failure
 ```


### PR DESCRIPTION
I wanted the ability to drop root privileges after opening the sockets. This assumes one can run `eap_proxy.py` via an external service like supervisord that supports restarting in the event the program exits.

This PR adds a couple options to support this use case.

Sample supervisord config (place in /etc/supervisor/conf.d/eap_proxy.conf):
```
[program:eap_proxy]
command=/usr/bin/python2 /root/eap_proxy.py --drop-root eth0 eth2
autostart=true
startretries=100
stdout_syslog=true
stderr_syslog=true
```