### PR TITLE
Add Python 3 support

### DIFF
--- a/eap_proxy.py
+++ b/eap_proxy.py
@@ -96,7 +96,11 @@ class struct_packet_mreq(ctypes.Structure):
         ("mr_address", ctypes.c_ubyte * 8))
 
 
-if_nametoindex = ctypes.CDLL(ctypes.util.find_library('c')).if_nametoindex
+try:
+    # if_nametoindex is available in socket module since Python 3.3
+    if_nametoindex = socket.if_nametoindex
+except AttributeError:
+    if_nametoindex = ctypes.CDLL(ctypes.util.find_library('c')).if_nametoindex
 
 
 def addsockaddr(sock, address):
@@ -248,7 +252,7 @@ def pingaddr(ipaddr, data='', timeout=1.0, strict=False):
 def strbuf(buf):
     """Return `buf` formatted as a hex dump (like tcpdump -xx)."""
     out = []
-    for i in xrange(0, len(buf), 16):
+    for i in range(0, len(buf), 16):
         octets = (ord(x) for x in buf[i:i + 16])
         pairs = []
         for octet in octets:


### PR DESCRIPTION
`ctypes.CDLL(ctypes.util.find_library('c')).if_nametoindex` always returns `0` on Python 3.7 for me (which results in a "No such device" error when trying to open the socket), but it looks like this method now exists in the `socket` module:

https://docs.python.org/3/library/socket.html#socket.if_nametoindex

Using it instead (if it exists) makes the code work on both Python 2 and 3. The only other change needed was `xrange()` -> `range()`.

```
(eap_proxy) $ python --version
Python 3.7.3
(eap_proxy) $ pylint eap_proxy.py
************* Module eap_proxy
eap_proxy.py:375:0: R0205: Class 'EdgeOS' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
eap_proxy.py:533:0: R0205: Class 'EAPProxy' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
```