### PR TITLE
add setup.py so zip archive can be pip-installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+"Setup script for eap_proxy."
+from setuptools import setup
+
+
+setup(
+    name="eap_proxy",
+    version="1.0",
+    description="Proxy EAP packets between interfaces on Linux-based routers.",
+    url="https://github.com/jaysoffian/eap_proxy",
+    author="Jay Soffian",
+    license="BSD",
+    py_modules=["eap_proxy"],
+    entry_points={"console_scripts": ["eap_proxy=eap_proxy:main"]},
+)


### PR DESCRIPTION
It seems to work:
```
root@OpenWrt:~# pip3 install https://github.com/tobiasmcnulty/eap_proxy/archive/master.zip
Collecting https://github.com/tobiasmcnulty/eap_proxy/archive/master.zip
  Downloading https://github.com/tobiasmcnulty/eap_proxy/archive/master.zip
     - 20 kB 35 kB/s
Using legacy setup.py install for eap-proxy, since package 'wheel' is not installed.
Installing collected packages: eap-proxy
    Running setup.py install for eap-proxy ... done
Successfully installed eap-proxy-1.0
```

The script itself is run without the `.py` extension:
```
root@OpenWrt:~# eap_proxy --help
usage: eap_proxy [-h] [--ping-gateway] [--ping-ip PING_IP]
                 [--ignore-when-wan-up] [--ignore-start] [--ignore-logoff]
                 [--restart-dhcp] [--set-mac] [--vlan-id VLAN_ID] [--daemon]
                 [--pidfile PIDFILE] [--syslog] [--run-as USER[:GROUP]]
                 [--promiscuous] [--debug] [--debug-packets]
                 IF_WAN IF_ROUTER
<snip>
```

I also removed the release I'd uploaded to PyPI so folks can't accidentally install that. Also, let me know if you want me to add you to the project on pypi, in case you wish to use it in the future.