### PR TITLE
Harden eap_proxy.sh script for use on USG

### DIFF
--- a/eap_proxy.sh.example
+++ b/eap_proxy.sh.example
@@ -24,5 +24,9 @@ if test -f /var/run/eap_proxy.pid; then
   kill $(head -1 /var/run/eap_proxy.pid) 2>/dev/null
 fi
 
+# Required for USG devices to survive a reboot
+# Replace ab:cd:ef:01:23:45 with the MAC address of the AT&T Router Gateway (RG)
+/opt/vyatta/sbin/vyatta-interfaces.pl --dev eth0.0 --set-mac ab:cd:ef:01:23:45
+
 /usr/bin/python /config/scripts/eap_proxy.py \
     "$IF_WAN" "$IF_ROUTER" "${CONFIG_OPTIONS[@]}" "${DAEMON_OPTIONS[@]}" &


### PR DESCRIPTION
With a USG 3P a reboot of the device requires a subsequent reboot of the AT&T Router Gateway (RG) or unplugging/plugging the Ethernet cable on the USG to the AT&T Router Gateway (RG), which both require physical access. This is not ideal as the bypass setup with a USG would not survive a regular reboot.  Manually setting the interface towards the AT&T ONT with the MAC address of the AT&T Router Gateway (RG) will solve this problem.