### PR TITLE
Error message caused by eth2 in admin down state

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,18 @@ debugging:
   --debug-packets       print packets in hex format to assist with debugging;
                         implies --debug
 ```
+## Troubleshooting 
+
+### USG
+
+#### Error message "IOError: [eth2] unexpected poll event: 8"
+
+The USG device by default has the secondary WAN port (eth2) enabled. After a hard reset of the device this will be the case as well. The above error message indicates that this interface is disabled (administrative down state). You can enable the interface via the CLI:
+
+```
+configure
+delete interfaces ethernet eth0 disable
+commit
+save
+exit
+```


### PR DESCRIPTION
Added Troubleshooting section that addresses the script's error message when eth2 on USG is in Admin down state.  This issue was e.g. raised in https://github.com/jaysoffian/eap_proxy/issues/28, but not addressed.